### PR TITLE
fix: Add saner logging defaults in the Azure app template

### DIFF
--- a/schematics/install/files/root/__rootDir__/main.azure.ts
+++ b/schematics/install/files/root/__rootDir__/main.azure.ts
@@ -3,7 +3,9 @@ import { NestFactory } from '@nestjs/core';
 import { <%= getRootModuleName() %> } from './<%= getRootModulePath() %>';
 
 export async function createApp(): Promise<INestApplication> {
-  const app = await NestFactory.create(<%= getRootModuleName() %>);
+  const app = await NestFactory.create(<%= getRootModuleName() %>, {
+    logger: ['error', 'warn'],
+  });
   app.setGlobalPrefix('api');
   
   await app.init();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe:
Provide saner logging defaults in schematics.
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the default NestJS logging settings are used in the `main.azure.ts` schematic, but as I have found out today, is very verbose (the bootstrap logging will be logged for every request made) for serverless usage and clutters data gathered by Azure Application Insights.

## What is the new behavior?

In the updated template for `main.azure.ts`, I have changed the logging settings to only log `error` and `warn` by default, so that only the things that matter get logged to Application Insights.

Of course it's just a template, so people can freely change this if they want more logging (or disable it entirely), but I think this makes the most sense to be the default for Azure.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information